### PR TITLE
Use 127.0.0.1 instead of localhost for identity

### DIFF
--- a/src/request/getToken.ts
+++ b/src/request/getToken.ts
@@ -24,7 +24,7 @@ async function genReplIdentityToken(): Promise<string> {
 }
 
 async function getDeploymentToken(): Promise<string> {
-  const res = await fetch('http://localhost:1105/getIdentityToken', {
+  const res = await fetch('http://127.0.0.1:1105/getIdentityToken', {
     body: JSON.stringify({ audience: 'modelfarm@replit.com' }),
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
# Why

Well, sometimes we end up with `localhost` resolving to ipv6 and that causes issues.

# What changed

Use 127.0.0.1 instead of localhost for identity.

We'll make it so that identity server also supports ipv6, so that we can support old clients, but that's separate from this PR.

# Test plan

- Run tests in deployments
- Get requests
- Weee
